### PR TITLE
removed emoji from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ Go through this file line-by-line and replace the template values with your own.
     <inceptionYear>2021</inceptionYear>
 
     <!--
-    👉 Note: in the elements below, we cannot use `${project-name}` as apparently property expansion does
+    Note: in the elements below, we cannot use `${project-name}` as apparently property expansion does
     not occur here despite the documentation at https://maven.apache.org/pom.html#Properties says.
 
     So be sure to replace all five `myproject`s below with your actual project name!

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 
 <!--
-👉 This is the TEMPLATE project object model or `pom.xml` file.
+This is the TEMPLATE project object model or `pom.xml` file.
 
 Go through this file line-by-line and replace the template values with your own.
 -->


### PR DESCRIPTION
## 🗒️ Summary
This character (possibly all utf-8 - I haven't checked) broke xml parsing on the registry-api repo.

It's unclear why this issue is only rearing its head now, but it seems like an easy decision to make to remove it from the template.

