### PR TITLE
Template now includes an example `log4j.properites` files

### DIFF
--- a/.github/workflows/secrets-detection.yaml
+++ b/.github/workflows/secrets-detection.yaml
@@ -47,7 +47,7 @@ jobs:
                     detect-secrets scan --disable-plugin AbsolutePathDetectorExperimental --baseline .secrets.new \
                         --exclude-files '\.secrets..*' \
                         --exclude-files '\.git.*' \
-                        --exclude-files 'target'
+                        --exclude-files 'target' \
                         --exclude-files '\.pre-commit-config.yaml'
                        
                     # if there is any difference between the known and newly detected secrets, break the build

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ _Installation instructions here. Include any system-wide requirements (`bres ins
 
 _Basic usage instructions here. If possible, make it so your program works correctly "out of the box" as an executable `.jar`, or as a drop-in `.war`, etc., without any additional configuration._
 
+_An example `log4j.properties` file is in `src/main/resources`; mention how to customize it as needed—or delete it if it doesn't apply to your app._
+
 
 ## 👥 Contributing
 
@@ -81,10 +83,12 @@ to produce a complete package. This runs all the phases necessary, including com
 -   `install` - install into your local repository
 -   `deploy` - deploy to a remote repository — note that the Roundup action does this automatically for releases
 
-#### :guardsman: Secrets Detection Setup and Update
+#### 💂‍♂️ Secrets Detection Setup and Update
+
 The PDS uses [Detect Secrets](https://nasa-ammos.github.io/slim/docs/guides/software-lifecycle/security/secrets-detection/)) to help prevent committing information to a repository that should remain secret.
 
 For Detect Secrets to work, there is a one-time setup required to your personal global Git configuration, as well as several steps to create or update the **required** `.secrets.baseline` file needed to avoid false positive failures of the software. See [the wiki entry on Detect Secrets](https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Git-and-Github-Guide#detect-secrets) to learn how to do this.
+
 
 #### 🪝 Pre-Commit Hooks
 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,62 @@
+# Example log4j.properties
+# ========================
+#
+# This is an example `log4j.properties` file that serves as a starting point
+# for your own application. It sets up the following:
+#
+# - Default log level is `WARN`, which is reasonable
+# - Default logging is to the standard error output (`stderr`), which is
+#   what you want¹
+#
+# The possible log levels are (listed in priority level):
+#
+# - `FATAL`: the most severe; the application will abort
+# - `ERROR`: a significant problem that requires attention
+# - `WARN`: potentially harmful and worth noting but not necessarily a failure
+# - `INFO`: general information about app progress
+# - `DEBUG`: detailed info useful for developers
+# - `TRACE`: even more detail than `DEBUG`
+#
+# There are special levels `OFF` and `ALL` which do what you expect.
+#
+# There is an additional appender commented-out below; feel free to enable it
+# and/or customize it.
+#
+# Below that are examples showing how to fine-tune the log levels per-package.
+
+
+log4j.rootCategory=WARN, console
+
+
+# Console Logging
+# ---------------
+
+log4j.appender.console = org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout = org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} [%-5p] (%F:%M:%L) %m%n
+
+
+# Example Rolling File Logging
+# ----------------------------
+#
+# This logs to a file named `logs/app.log.2024-01-01`, etc., making a new file
+# each day. If you comment this out, add `, rolling` to the `log4j.rootCategory`
+# or to a package-specific declaration.
+#
+# log4j.appender.rolling = org.apache.log4j.DailyRollingFileAppender
+# log4j.appender.rolling.File = logs/app.log
+# log4j.appender.rolling.Append = true
+# log4j.appender.rolling.DatePattern = '.'yyyy-MM-dd
+# log4j.appender.rolling.layout = org.apache.log4j.PatternLayout
+# log4j.appender.rolling.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} [%-5p] (%F:%M:%L) %m%n
+
+
+# Example Package-Level Directives
+# --------------------------------
+#
+# These show examples of how to on `DEBUG` logging for one module (up from the
+# default of `WARN`) for the `gov.nasa.pds.xml.utils` package and completely
+# turn off logging for all packages/sub-packages under `com.nickelback`:
+#
+# log4j.logger.gov.nasa.pds.xml.utils = DEBUG
+# log4j.logger.com.nickelback = OFF


### PR DESCRIPTION
## 🗒️ Summary

Merge this to add a starter `log4j.properties` file to the Java template.

## ⚙️ Test Data and/or Report

Really not applicable to this change, but here we go:
```
$ mvn clean package
…
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
…
```

## ♻️ Related Issues

- #61 
