### PR TITLE
Update .pre-commit-config.yaml to ignore plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,8 @@ repos:
             args:
               - '--baseline'
               - '.secrets.baseline'
+              - '--disable-plugin'
+              - 'AbsolutePathDetectorExperimental'
               - --exclude-files '\.secrets..*'
               - --exclude-files '\.git.*'
               - --exclude-files 'target'


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Getting numerous failures in Java repo for this experimental plugin. This now matches what we have here:  https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Git-and-Github-Guide#detect-secrets

## ⚙️ Test Data and/or Report
In java repo:

```
$ gcm "Update precommit"
Detect secrets...........................................................Passed
Detect secrets...........................................................Passed
Detect secrets...........................................................Passed
[main 00b6a33] Update precommit
```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
None