### PR TITLE
Transition secrets from OSSRH to Central Repo Portal

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -74,8 +74,8 @@ jobs:
                     assembly: stable
                     packages: openjdk11-jdk
                 env:
-                    ossrh_username: ${{secrets.OSSRH_USERNAME}}
-                    ossrh_password: ${{secrets.OSSRH_PASSWORD}}
+                    central_portal_username: ${{secrets.CENTRAL_REPOSITORY_USERNAME}}
+                    central_portal_token: ${{secrets.CENTRAL_REPOSITORY_TOKEN}}
                     CODE_SIGNING_KEY: ${{secrets.CODE_SIGNING_KEY}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
 

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -78,8 +78,8 @@ jobs:
                     assembly: unstable
                     packages: openjdk11-jdk
                 env:
-                    ossrh_username: ${{secrets.OSSRH_USERNAME}}
-                    ossrh_password: ${{secrets.OSSRH_PASSWORD}}
+                    central_portal_username: ${{secrets.CENTRAL_REPOSITORY_USERNAME}}
+                    central_portal_token: ${{secrets.CENTRAL_REPOSITORY_TOKEN}}
                     CODE_SIGNING_KEY: ${{secrets.CODE_SIGNING_KEY}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
 


### PR DESCRIPTION
## 🗒️ Summary

The Roundup Action now uses new variables—and GitHub Actions now has new secrets—in support of the transition from the older OSSRH to the newer Central Repository Portal.

Merging this will bring the template repository for Java up-to-date with these new variables and secrets (which are now in use by the Roundup Action and installed in the NASA-PDS organization, respectively).

## ⚙️ Test Data and/or Report

N/A.

## ♻️ Related Issues

- https://github.com/NASA-PDS/software-issues-repo/issues/128
- https://github.com/NASA-PDS/template-repo-java/issues/67
- https://github.com/NASA-PDS/software-issues-repo/issues/132


